### PR TITLE
Ftr data queue

### DIFF
--- a/Comms Protocol CSharp/Comms Protocol CSharp Tests/Comms Protocol CSharp Tests.csproj
+++ b/Comms Protocol CSharp/Comms Protocol CSharp Tests/Comms Protocol CSharp Tests.csproj
@@ -52,6 +52,8 @@
     <Compile Include="Motus_1_RawDataPacketTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SerializeUnitTests.cs" />
+    <Compile Include="DataQueueUnitTests.cs" />
+    <Compile Include="DataPacketUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Comms Protocol CSharp/Comms Protocol CSharp Tests/DataPacketUnitTests.cs
+++ b/Comms Protocol CSharp/Comms Protocol CSharp Tests/DataPacketUnitTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Comms_Protocol_CSharp;
+
+namespace Comms_Protocol_CSharp_Tests
+{
+    [TestClass]
+    public class DataPacketUnitTests
+    {
+        [TestMethod]
+        public void DataPacket_TestConstructor()
+        {
+            DataPacket defaultConstr = new DataPacket();
+            byte[] test = new byte[] { 0, 1, 2, 3, 4 };
+            DataPacket constr = new DataPacket(ValidPacketTypes.test_packet, (short)test.Length, test);
+
+            Assert.AreEqual(ValidPacketTypes.end_valid_packet_types, defaultConstr.Type);
+            Assert.AreEqual(-1, defaultConstr.ExpectedLen);
+
+            Assert.AreEqual(ValidPacketTypes.test_packet, constr.Type);
+            Assert.AreEqual(test.Length, constr.ExpectedLen);
+            for (int i = 0; i < constr.ExpectedLen; i++)
+                Assert.AreEqual(constr.Payload[i], test[i]);
+        }
+
+        [TestMethod]
+        public void DataPacket_TestSerialize()
+        {
+            DataPacket packet = new DataPacket();
+            short testPayloadLen = 5;
+            byte[] stream = new byte[] { (byte)ValidPacketTypes.test_packet, (byte)(testPayloadLen >> 8),
+                                    (byte)(testPayloadLen), 0, 1, 2, 3, 4 };
+
+            packet.Serialize(stream, 0);
+            Assert.AreEqual(ValidPacketTypes.test_packet, packet.Type);
+            Assert.AreEqual(testPayloadLen, packet.ExpectedLen);
+            for (int i = 0; i < packet.ExpectedLen; i++)
+                Assert.AreEqual(packet.Payload[i], stream[DataPacket.DataStartPos + i]);
+        }
+    }
+}

--- a/Comms Protocol CSharp/Comms Protocol CSharp Tests/DataQueueUnitTests.cs
+++ b/Comms Protocol CSharp/Comms Protocol CSharp Tests/DataQueueUnitTests.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Comms_Protocol_CSharp;
+
+namespace Comms_Protocol_CSharp_Tests
+{
+    [TestClass]
+    public class DataQueueUnitTests
+    {
+        private byte[] sampleMotusPayload = new byte[] { 0, 1, 2, 3, 4, 5, 6,
+                                                    7, 8, 9, 10, 11, 12, 13,
+                                                    14, 15, 16, 17};
+
+        private void FillQueue(DataQueue queue, DataPacket packet)
+        {
+            for (int i = 0; i < queue.MaxSize; i++)
+                queue.Add(packet);
+        }
+
+        [TestMethod]
+        public void DataQueue_TestConstructor()
+        {
+            DataQueue defaultQueue = new DataQueue();
+            DataQueue queue = new DataQueue(128);
+            Assert.AreEqual(64, defaultQueue.MaxSize);
+            Assert.AreEqual(128, queue.MaxSize);
+        }
+
+        [TestMethod]
+        public void DataQueue_TestIsEmpty()
+        {
+            DataQueue queue = new DataQueue();
+            Assert.IsTrue(queue.IsEmpty());
+        }
+
+        [TestMethod]
+        public void DataQueue_TestAddPacket()
+        {
+            Motus_1_RawDataPacket packet = new Motus_1_RawDataPacket(sampleMotusPayload);
+            DataQueue queue = new DataQueue();
+
+            Assert.IsTrue(queue.Add(packet));
+            Assert.IsFalse(queue.IsEmpty());
+        }
+
+        [TestMethod]
+        public void DataQueue_TestAddOverFlowProtection()
+        {
+            Motus_1_RawDataPacket packet = new Motus_1_RawDataPacket(sampleMotusPayload);
+            DataQueue queue = new DataQueue();
+
+            for (int i = 0; i < queue.MaxSize; i++)
+                Assert.IsTrue(queue.Add(packet));
+
+            Assert.IsFalse(queue.Add(packet));
+        }
+
+        [TestMethod]
+        public void DataQueue_TestGet()
+        {
+            Motus_1_RawDataPacket packet = new Motus_1_RawDataPacket(sampleMotusPayload);
+            DataQueue queue = new DataQueue();
+            queue.Add(packet);
+
+            DataPacket getPacket = queue.Get();
+            Assert.AreEqual(packet.Type, getPacket.Type);
+            Assert.AreEqual(packet.ExpectedLen, getPacket.ExpectedLen);
+            for (int i = 0; i < packet.ExpectedLen; i++)
+                Assert.AreEqual(packet.Payload[i], getPacket.Payload[i]);
+        }
+
+        [TestMethod]
+        public void DataQueue_TestGetUnderFlowProtection()
+        {
+            Motus_1_RawDataPacket packet = new Motus_1_RawDataPacket(sampleMotusPayload);
+            DataQueue queue = new DataQueue();
+
+            FillQueue(queue, packet);
+
+            int count;
+            for (count = 0; !queue.IsEmpty(); count++)
+            {
+                DataPacket getPacket = queue.Get();
+                Assert.AreEqual(packet.Type, getPacket.Type);
+                Assert.AreEqual(packet.ExpectedLen, getPacket.ExpectedLen);
+                for (int j = 0; j < packet.ExpectedLen; j++)
+                    Assert.AreEqual(packet.Payload[j], getPacket.Payload[j]);
+            }
+
+            Assert.AreEqual(count, queue.MaxSize);
+            Assert.IsTrue(queue.IsEmpty());
+            DataPacket badPacket = queue.Get();
+            Assert.AreEqual(ValidPacketTypes.end_valid_packet_types, badPacket.Type);
+            Assert.AreEqual(-1, badPacket.ExpectedLen);
+        }
+
+        [TestMethod]
+        public void DataQueue_TestGetStreamable()
+        {
+            byte[] stream = new byte[2048];
+            Motus_1_RawDataPacket packet = new Motus_1_RawDataPacket(sampleMotusPayload);
+            DataQueue queue = new DataQueue();
+            int expectedNumBytesToQueue = ((18 + DataPacket.NumOverHeadBytes) * queue.MaxSize);
+
+            FillQueue(queue, packet);
+            int numBytesQueued = queue.GetStreamable(stream, stream.Length);
+            Assert.AreEqual(expectedNumBytesToQueue, numBytesQueued);
+            Assert.IsTrue(queue.IsEmpty());
+
+            for (int i = 0; i < numBytesQueued; )
+            {
+                DataPacket rebuilt = new DataPacket();
+                i += rebuilt.Serialize(stream, i);
+                Assert.AreEqual(packet.Type, rebuilt.Type);
+                Assert.AreEqual(packet.ExpectedLen, rebuilt.ExpectedLen);
+                for (int j = 0; j < rebuilt.ExpectedLen; j++)
+                    Assert.AreEqual(packet.Payload[j], rebuilt.Payload[j]);
+            }
+        }
+
+        [TestMethod]
+        public void DataQueue_TestParseStreamable()
+        {
+            byte[] stream = new byte[2048];
+            Motus_1_RawDataPacket packet = new Motus_1_RawDataPacket(sampleMotusPayload);
+            DataQueue queue = new DataQueue();
+
+            FillQueue(queue, packet);
+            int numBytesQueued = queue.GetStreamable(stream, stream.Length);
+            FillQueue(queue, packet);
+
+            DataQueue queue2 = new DataQueue();
+            queue2.ParseStreamable(stream, stream.Length);
+
+            while (!queue2.IsEmpty() && !queue.IsEmpty())
+            {
+                DataPacket packet1 = queue.Get();
+                DataPacket packet2 = queue2.Get();
+
+                // Ensure packet1 is the same as packet
+                Assert.AreEqual(packet.Type, packet1.Type);
+                Assert.AreEqual(packet.ExpectedLen, packet1.ExpectedLen);
+                for (int j = 0; j < packet1.ExpectedLen; j++)
+                    Assert.AreEqual(packet.Payload[j], packet1.Payload[j]);
+
+                // Ensure packet2 is the same as packet1
+                Assert.AreEqual(packet1.Type, packet2.Type);
+                Assert.AreEqual(packet1.ExpectedLen, packet2.ExpectedLen);
+                for (int j = 0; j < packet2.ExpectedLen; j++)
+                    Assert.AreEqual(packet1.Payload[j], packet2.Payload[j]);
+            }
+        }
+    }
+}

--- a/Comms Protocol CSharp/Comms Protocol CSharp Tests/Motus_1_RawDataPacketTests.cs
+++ b/Comms Protocol CSharp/Comms Protocol CSharp Tests/Motus_1_RawDataPacketTests.cs
@@ -10,10 +10,52 @@ namespace Comms_Protocol_CSharp_Tests
         [TestMethod]
         public void Motus_1_PacketTestConstructor()
         {
+            byte[] testPayload = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 };
             Motus_1_RawDataPacket packet = new Motus_1_RawDataPacket();
+            Motus_1_RawDataPacket packet1 = new Motus_1_RawDataPacket(testPayload);
+            DataPacket dPacket = new DataPacket(ValidPacketTypes.motus_1_raw_data_packet, (short)testPayload.Length, testPayload);
+            Motus_1_RawDataPacket packet2 = new Motus_1_RawDataPacket(dPacket);
+
             Assert.AreEqual(ValidPacketTypes.motus_1_raw_data_packet,
                 packet.Type);
             Assert.AreEqual(18, packet.ExpectedLen);
+            Assert.AreEqual(ValidPacketTypes.motus_1_raw_data_packet,
+                packet1.Type);
+            Assert.AreEqual(18, packet1.ExpectedLen);
+            Assert.AreEqual(ValidPacketTypes.motus_1_raw_data_packet,
+                            packet2.Type);
+            Assert.AreEqual(18, packet2.ExpectedLen);
+            for (int i = 0; i < testPayload.Length; i++)
+            {
+                Assert.AreEqual(testPayload[i], packet1.Payload[i]);
+                Assert.AreEqual(testPayload[i], packet2.Payload[i]);
+            }
+
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Accepted illegal payload")]
+        public void Motus_1_PacketTestInvalidConstructor()
+        {
+            byte[] invalidBytePayload = new byte[12];
+            Motus_1_RawDataPacket packet = new Motus_1_RawDataPacket(invalidBytePayload);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException), "Accepted illegal payload")]
+        public void Motus_1_PacketTestInvalidConstructor2()
+        {
+            byte[] invalidBytePayload = new byte[12];
+            DataPacket dPacket = new DataPacket(ValidPacketTypes.motus_1_raw_data_packet, 
+                (short)invalidBytePayload.Length, invalidBytePayload);
+
+            Motus_1_RawDataPacket packet = new Motus_1_RawDataPacket(dPacket);
+            Assert.AreEqual(ValidPacketTypes.motus_1_raw_data_packet, packet.Type);
+            Assert.AreEqual(18, packet.ExpectedLen);
+
+            DataPacket dPacket1 = new DataPacket(ValidPacketTypes.motus_1_raw_data_packet,
+                18, invalidBytePayload);
+            Motus_1_RawDataPacket packet1 = new Motus_1_RawDataPacket(dPacket1);
         }
 
         [TestMethod]

--- a/Comms Protocol CSharp/Comms Protocol CSharp/Comms Protocol CSharp.csproj
+++ b/Comms Protocol CSharp/Comms Protocol CSharp/Comms Protocol CSharp.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DataPacket.cs" />
+    <Compile Include="DataQueue.cs" />
     <Compile Include="Motus_1_RawDataPacket.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SerializeUtilities.cs" />

--- a/Comms Protocol CSharp/Comms Protocol CSharp/DataPacket.cs
+++ b/Comms Protocol CSharp/Comms Protocol CSharp/DataPacket.cs
@@ -3,12 +3,32 @@ namespace Comms_Protocol_CSharp
 {
     public class DataPacket
     {
+        public const short NumOverHeadBytes = 3;
+        private const int _typePos = 0;
+        private const int _lenPos1 = 1;
+        private const int _lenPos2 = 2;
+        private const int _dataStartPos = 3;
+
         private byte[] _payload = new byte[0];
-        private ValidPacketTypes _type = 0;
+        private ValidPacketTypes _type = ValidPacketTypes.end_valid_packet_types;
         private short _expectedLen = -1;
         public byte[] Payload { get; set; }
         public ValidPacketTypes Type { get; set; }
         public short ExpectedLen { get; set; }
+
+        public byte[] DeBuffer()
+        {
+            if (_expectedLen == -1)
+                return null;
+
+            byte[] buffer = new byte[NumOverHeadBytes + _expectedLen];
+            buffer[_typePos] = (byte)_type;
+            SerializeUtilities.BufferInt16InToByteArray(_expectedLen, buffer, 
+                _lenPos1, Endianness.big_endian);
+            for (int i = 0; i < _expectedLen; i++)
+                buffer[_dataStartPos + i] = _payload[i];
+            return buffer;
+        }
     }
 
     public enum ValidPacketTypes

--- a/Comms Protocol CSharp/Comms Protocol CSharp/DataQueue.cs
+++ b/Comms Protocol CSharp/Comms Protocol CSharp/DataQueue.cs
@@ -1,0 +1,84 @@
+﻿namespace Comms_Protocol_CSharp
+{
+    class DataQueue
+    {
+        private int _bufferSize;
+        private int _head = 0;
+        private int _tail = 0;
+        private byte[] _buffer;
+
+        public int Index { get; }
+
+        public DataQueue()
+        {
+            _bufferSize = 1024;
+            _buffer = new byte[_bufferSize];
+        }
+
+        public DataQueue(int size)
+        {
+            _bufferSize = size;
+            _buffer = new byte[_bufferSize];
+        }
+
+        public int GetBufferSpace()
+        {
+            return (_bufferSize - _head);
+        }
+
+        public void QueueDataPacket(DataPacket packet)
+        {
+            byte[] serial = packet.DeBuffer();
+            short len = (short)(packet.ExpectedLen + DataPacket.NumOverHeadBytes);
+            if ((serial != null) && (GetBufferSpace() > len))
+            {
+                for (int i = 0; i < serial.Length; i++)
+                    _buffer[_head++] = serial[i];
+            }
+        }
+
+        public void QueueBytes(byte[] bytes)
+        {
+            int len = bytes.Length;
+            if (GetBufferSpace() > len)
+            {
+                for (int i = 0; i < len; i++)
+                    _buffer[_head++] = bytes[i];
+            }
+        }
+
+        public void Flush()
+        {
+            _head = 0;
+            _tail = 0;
+        }
+
+        public byte[] GetAllBytes()
+        {
+            Flush();
+            return _buffer;
+        }
+
+        public DataPacket GetDataPacket()
+        {
+            DataPacket packet = new DataPacket();
+            if ((_head - _tail) > DataPacket.NumOverHeadBytes)
+            {
+                ValidPacketTypes type = (ValidPacketTypes)_buffer[_tail++];
+                short len = (short)_buffer[_tail++];
+                len <<= 8;
+                len |= (short)_buffer[_tail++];
+                if ((_head - _tail) >= len)
+                {
+                    byte[] payload = new byte[len];
+                    for (int i = 0; i < len; i++)
+                        payload[i] = _buffer[_tail++];
+                    packet.Type = type;
+                    packet.Payload = payload;
+                }
+            }
+
+            return packet;
+        }
+    }
+}

--- a/Comms Protocol CSharp/Comms Protocol CSharp/Motus_1_RawDataPacket.cs
+++ b/Comms Protocol CSharp/Comms Protocol CSharp/Motus_1_RawDataPacket.cs
@@ -11,6 +11,13 @@ namespace Comms_Protocol_CSharp
             this.Payload = new byte[0];
         }
 
+        public Motus_1_RawDataPacket(byte[] payload)
+        {
+            this.Type = ValidPacketTypes.motus_1_raw_data_packet;
+            this.ExpectedLen = 18;
+            this.Serialize(payload);
+        }
+
         public void Serialize(byte[] payload)
         {
             if (payload.Length != this.ExpectedLen)

--- a/Comms Protocol CSharp/Comms Protocol CSharp/Motus_1_RawDataPacket.cs
+++ b/Comms Protocol CSharp/Comms Protocol CSharp/Motus_1_RawDataPacket.cs
@@ -18,6 +18,23 @@ namespace Comms_Protocol_CSharp
             this.Serialize(payload);
         }
 
+        public Motus_1_RawDataPacket(DataPacket packet)
+        {
+            if ((packet.Type != ValidPacketTypes.motus_1_raw_data_packet) ||
+                (packet.ExpectedLen != 18))
+            {
+                this.Type = ValidPacketTypes.motus_1_raw_data_packet;
+                this.ExpectedLen = 18;
+                this.Payload = new byte[0];
+            }
+            else
+            {
+                this.Type = packet.Type;
+                this.ExpectedLen = packet.ExpectedLen;
+                this.Serialize(packet.Payload);
+            }
+        }
+
         public void Serialize(byte[] payload)
         {
             if (payload.Length != this.ExpectedLen)


### PR DESCRIPTION
Implemented the DataQueue class which allows us to queue DataPacket objects into an object queue. We can then serialize these objects into a single byte array so that streaming large amounts of objects becomes much simpler. 